### PR TITLE
enable "configure" to receive quoted arguments

### DIFF
--- a/opam-compiler-conf.sh
+++ b/opam-compiler-conf.sh
@@ -225,7 +225,7 @@ case "$1" in
     configure)
         # configure the ocaml distribution for compilation
         shift
-        ./configure --prefix $PREFIX $*
+        ./configure --prefix $PREFIX "$@"
         ;;
     install)
         # check that ./configure was run


### PR DESCRIPTION
This fix enables passing quoted arguments to `configure`:
> ./opam-compiler-conf.sh configure -with-debug-runtime -cc "gcc -fPIC" -aspp "gcc -c -fPIC"

Bash sucks. :-1:

Thanks for the nifty script.